### PR TITLE
Fix SARIF path for JS/TS file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,10 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
+            sarif-filename: javascript.sarif
           - language: python
             build-mode: none
+            sarif-filename: python.sarif
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -93,7 +95,7 @@ jobs:
         with:
           category: "/language:${{matrix.language}}"
           upload: false # Upload later, see below
-          output: sarif-results/${{ matrix.language }}.sarif
+          output: sarif-results
 
       # Filter out test files
       - name: filter-sarif
@@ -102,7 +104,7 @@ jobs:
           patterns: |
             -application/backend/app/tests
             -application/frontend/tests
-          input: sarif-results/${{ matrix.language }}.sarif
+          input: sarif-results/${{ matrix.sarif-filename }}
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -108,7 +108,7 @@ jobs:
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze ${{ matrix.language }}
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
@@ -108,12 +108,12 @@ jobs:
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload loc as a Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sarif-results
           path: sarif-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           category: "/language:${{matrix.language}}"
           upload: false # Upload later, see below
-          output: sarif-results
+          output: sarif-results/${{ matrix.language }}.sarif
 
       # Filter out test files
       - name: filter-sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,10 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
+            sarif-filename: javascript.sarif  # the file name is different!
           - language: python
             build-mode: none
+            sarif-filename: python.sarif
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -102,7 +104,7 @@ jobs:
           patterns: |
             -application/backend/app/tests
             -application/frontend/tests
-          input: sarif-results/${{ matrix.language }}.sarif
+          input: sarif-results/${{ matrix.sarif-filename }}
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -108,7 +108,7 @@ jobs:
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze ${{ matrix.language }}
+    name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
@@ -45,10 +45,8 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
-            sarif-filename: javascript.sarif
           - language: python
             build-mode: none
-            sarif-filename: python.sarif
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -104,17 +102,17 @@ jobs:
           patterns: |
             -application/backend/app/tests
             -application/frontend/tests
-          input: sarif-results/${{ matrix.sarif-filename }}
+          input: sarif-results/${{ matrix.language }}.sarif
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload loc as a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: sarif-results
+          name: sarif-results-${{matrix.language}}
           path: sarif-results
           retention-days: 1


### PR DESCRIPTION
* Fix output path for JS/TS files. Fixes #35. 
* Update `upload-artifact` version.